### PR TITLE
Feature/settings update username

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Clone this repo, run `npm install`, and then `pod install` inside the /ios direc
 
 ### Todo:
 - Settings page
-  - [] Ability to update username
+  - [X] Ability to update username
   - [] Player stats (Win/Loss, total games played)
 - Multiplayer Lobby & Matchmaking
   - [] The host should be able to Start a match once Players is filled

--- a/components/screens/Registration.tsx
+++ b/components/screens/Registration.tsx
@@ -17,12 +17,16 @@ export default function Register({ navigation }: Props) {
   const [username, setUsername] = useState("")
   const [email, setEmail] = useState("")
   const [password, setPassword] = useState("")
-  const [error, setError] = useState<String | null>(null)
+  const [error, setError] = useState({})
+
+  useEffect(() => {
+    validateUsername()
+  }, [username])
 
   const register = async () => {
     // first, check that the username is unique
     // if it's unique, then try to create the new auth account
-    setError(null)
+    setError({})
 
     await firestore()
       .collection('users')
@@ -31,7 +35,7 @@ export default function Register({ navigation }: Props) {
       .then(querySnapshot => {
         // querySnapshot.empty still true if size is 0...?
         if (querySnapshot.size > 0) {
-          return setError('That username is taken!')
+          return setError({userName: 'That username is taken!'})
         }
         auth()
           .createUserWithEmailAndPassword(email, password)
@@ -55,13 +59,23 @@ export default function Register({ navigation }: Props) {
           })
           .catch(error => {
             if (error.code === 'auth/email-already-in-use') {
-              setError('That email address is already in use!')
+              setError({email: 'That email address is already in use!'})
             }
             if (error.code === 'auth/invalid-email') {
-              setError('That email address is invalid!')
+              setError({email: 'That email address is invalid!'})
             }
           })
       })
+  }
+
+  const validateUsername = () => {
+    if (username.length < 3) {
+      return setError({ userName: "Your username must be at least 3 characters" })
+    }
+    if (username.match(/[^a-zA-Z0-9]/)) {
+      return setError({ userName: "Usernames can only include letters and numbers" })
+    }
+    return setError({})
   }
 
   return (
@@ -78,6 +92,9 @@ export default function Register({ navigation }: Props) {
           autoCapitalize="none"
           onChangeText={value => setUsername(value)}
         />
+        {error.userName && (
+          <Text style={styles.error}>{error.userName}</Text>
+        )}
         <TextInput
           placeholder="Email"
           placeholderTextColor="#aaaaaa"
@@ -87,6 +104,9 @@ export default function Register({ navigation }: Props) {
           autoCapitalize="none"
           onChangeText={value => setEmail(value)}
         />
+        {error.email && (
+          <Text style={styles.error}>{error.email}</Text>
+        )}
         <TextInput
           placeholder="Password"
           placeholderTextColor="#aaaaaa"
@@ -98,9 +118,7 @@ export default function Register({ navigation }: Props) {
           autoCapitalize="none"
           onChangeText={value => setPassword(value)}
         />
-        {error && (
-          <Text style={styles.error}>{error}</Text>
-        )}
+        
         <TouchableOpacity
           style={styles.button}
           onPress={() => register()}

--- a/components/screens/Settings.tsx
+++ b/components/screens/Settings.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react'
 
-import { StyleSheet, Text, View, Button } from 'react-native'
+import { StyleSheet, Text, TextInput, View, Button } from 'react-native'
 
 import auth from '@react-native-firebase/auth'
 import firestore from '@react-native-firebase/firestore'
@@ -13,7 +13,7 @@ interface User {
 
 export default function Settings(props: any) {
   const [user, setUser] = useState<User | null>(null)
-
+  const [userName, setUsername] = useState('')
   useEffect(() => {
     // get the full current user document
     firestore()
@@ -39,7 +39,14 @@ export default function Settings(props: any) {
 
   return (
     <View style={styles.container}>
-      <Text>Coming Soon: Edit username</Text>
+      <TextInput
+        style={{ height: 40 }}
+        placeholder="Username"
+        onChangeText={text => {
+          setUsername(text)
+        }}
+        defaultValue={user.name}
+      />
       <Button onPress={() => auth().signOut().then(() => console.log('User signed out!'))} title="Sign Out" />
     </View>
   )

--- a/components/screens/Settings.tsx
+++ b/components/screens/Settings.tsx
@@ -48,6 +48,38 @@ export default function Settings(props: any) {
     }
     return setError({})
   }
+
+  const saveUsername = () => {
+    if (Object.keys(error).length) {
+      return 
+    }
+    /* Faking uniqueness*/
+    firestore()
+      .collection('users')
+      .where('name', '==', userName)
+      .get()
+      .then(querySnapshot => {
+        if (!querySnapshot) {
+          return console.error('update failed while looking for duplicates')
+        }
+        const existing = querySnapshot.docs.length
+        if (existing) {
+          return setError({userName: "That username is taken"})
+        }
+        // if it hasn't been found, update the username
+        firestore()
+          .collection('users')
+          .doc(user.id)
+          .update({
+            name: userName
+          })
+          .then(() => {
+            console.log('Username updated!');
+            // some sort of nice notification here
+          });  
+      })
+  }
+
   if (!user) {
     return <View style={styles.container}><Text>Error: User Not Found</Text></View>
   }
@@ -63,6 +95,7 @@ export default function Settings(props: any) {
         defaultValue={user.name}
       />
       {error.userName && <Text>{error.userName}</Text>}
+      <Button onPress={saveUsername} title="Save" />
       <Button onPress={() => auth().signOut().then(() => console.log('User signed out!'))} title="Sign Out" />
     </View>
   )

--- a/components/screens/Settings.tsx
+++ b/components/screens/Settings.tsx
@@ -29,6 +29,7 @@ export default function Settings(props: any) {
           ...data,
           id: querySnapshot.docs[0].id
         }
+        setUsername(data.name)
         return setUser(withId)
       })
   }, [])

--- a/components/screens/Settings.tsx
+++ b/components/screens/Settings.tsx
@@ -14,6 +14,7 @@ interface User {
 export default function Settings(props: any) {
   const [user, setUser] = useState<User | null>(null)
   const [userName, setUsername] = useState('')
+  const [error, setError] = useState({})
   useEffect(() => {
     // get the full current user document
     firestore()
@@ -34,6 +35,19 @@ export default function Settings(props: any) {
       })
   }, [])
 
+  useEffect(() => {
+    validateUsername()
+  }, [userName])
+
+  const validateUsername = () => {
+    if (userName.length < 3) {
+      return setError({userName: "Your username must be at least 3 characters"})
+    }
+    if (userName.match(/[^a-zA-Z0-9]/)) {
+      return setError({userName: "Usernames can only include letters and numbers"})
+    }
+    return setError({})
+  }
   if (!user) {
     return <View style={styles.container}><Text>Error: User Not Found</Text></View>
   }
@@ -48,6 +62,7 @@ export default function Settings(props: any) {
         }}
         defaultValue={user.name}
       />
+      {error.userName && <Text>{error.userName}</Text>}
       <Button onPress={() => auth().signOut().then(() => console.log('User signed out!'))} title="Sign Out" />
     </View>
   )


### PR DESCRIPTION
Adds the ability to update a player's username in the Setting page. Needs styling.  

Also includes validations:
- Player name must be at least 3 characters, only a-zA-Z0-9 allowed
- Player name MUST be unique. Since Firestore doesn't allow true unique fields outside of the index, this is a wonky way to enforce unique usernames. 

Local username validations added to the Registration page