### PR TITLE
Issue: players joining/hosting multiple matches

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,12 @@ Clone this repo, run `npm install`, and then `pod install` inside the /ios direc
   - [] The host should be able to Start a match once Players is filled
     - [] When the host starts the match, the host and players should be moved to the /match/:matchId screen
       - [] If I'm a Player in a Match Lobby, and the Match['status'] goes from 'matchmaking' to 'starting', then I should navigate to /match/:matchId
-  - [] A player should only be able to join one match at a time
+  - [X] A player should only be able to join or host one match at a time
   - [] Players must confirm they want to back out of a Match Lobby 
   - [] Players should be removed if they leave a Match Lobby
   - [] [#notSureIf]: A Host should enter the Match [words] before starting the match
+  - [] Sorting on MultiPlayer screen: 'my' match (whether as a host or player) should be first  
+  - [] Filtering on MultiPlayer screen: debug broken realtime updates 
   - [] Set up tailwind, and style all initial views
   - [] Generate and implement a WIP logo for development
 

--- a/components/screens/Multiplayer.tsx
+++ b/components/screens/Multiplayer.tsx
@@ -27,7 +27,6 @@ export default function Multiplayer(props: any) {
   const [matches, setMatches] = useState([])
 
   useEffect(() => {
-
     // get the full current user document
     firestore()
       .collection('users')
@@ -44,26 +43,38 @@ export default function Multiplayer(props: any) {
         }
         return setUser(withId)
       })
+  }, [props.user])
 
-    // get a collection of all matches
-    // sort by newest first (created_at)
-    // filter out matches with status: in progress, abandoned, complete
+
+  /* 
+    Get a manicured list of collections
+    Sorted by newest-first, limit of 100
+    Only games that are in matchmaking or in progress
+  */
+  useEffect(() => {
     firestore()
       .collection('matches')
+      .where('status', 'in', ['matchmaking', 'in-progress'])
+      .orderBy('created_at', 'desc')
+      .limit(100)
       .onSnapshot(querySnapshot => {
-        const matchCollection:Match[] = [];
-
-        querySnapshot.forEach((documentSnapshot:any) => {
-          const data:Match = documentSnapshot.data()
+        const matchCollection: Match[] = [];
+        querySnapshot?.forEach((documentSnapshot: any) => {
+          // console.log(documentSnapshot)
+          const data: Match = documentSnapshot.data()
           matchCollection.push({
             ...data,
             id: documentSnapshot.id
           });
         });
+
+        // band-aid for a bug...
+        if (!matchCollection.length) { return }
+
         setMatches(matchCollection)
       })
+  }, [])
 
-  }, [props.user])
 
   const createNewLobby = () => {
     firestore()

--- a/components/screens/Multiplayer.tsx
+++ b/components/screens/Multiplayer.tsx
@@ -131,8 +131,8 @@ export default function Multiplayer(props: any) {
 
   return (
     <View style={styles.container}>
+
       {!committed && <Button title="Host a Match" onPress={() => createNewLobby()} />}
-      
 
       <Text>Matches</Text>
       <FlatList

--- a/components/screens/Multiplayer.tsx
+++ b/components/screens/Multiplayer.tsx
@@ -25,6 +25,7 @@ interface Match {
 export default function Multiplayer(props: any) {
   const [user, setUser] = useState<User | null>(null)
   const [matches, setMatches] = useState([])
+  const [committed, setCommitted] = useState(true)
 
   useEffect(() => {
     // get the full current user document
@@ -75,6 +76,22 @@ export default function Multiplayer(props: any) {
       })
   }, [])
 
+  /* Check matches to see if user is a host or player already */
+  useEffect(() => {
+    const playing = matches?.find(m => {
+      return m.players?.find(p => {
+        return p.id === user?.id
+      })
+    })
+
+    const hosting = matches?.find(m => m.host.uid === user?.id)
+
+    if (playing || hosting) {
+      setCommitted(true)
+    } else {
+      setCommitted(false)
+    }
+  }, [matches])
 
   const createNewLobby = () => {
     firestore()
@@ -130,7 +147,8 @@ export default function Multiplayer(props: any) {
               { /* I can join the match if: */
                 item.host.uid !== user?.id && /* I'm not the host */
                 item.players.length < 4 && /* There is an empty space in [players] */
-                (item.players && !item.players.find(p => p.id === user?.id)) && /* I haven't already joined */
+                (item.players && !item.players.find(p => p.id === user?.id)) && /* I haven't already joined this match */
+                !committed && /* I haven't joined ANY active match */
                 (
                   <Button title="Join" onPress={() => joinMatch(item)} />
                 )

--- a/components/screens/Multiplayer.tsx
+++ b/components/screens/Multiplayer.tsx
@@ -55,7 +55,7 @@ export default function Multiplayer(props: any) {
   useEffect(() => {
     firestore()
       .collection('matches')
-      .where('status', 'in', ['matchmaking', 'in-progress'])
+      // .where('status', 'in', ['matchmaking', 'in-progress'])
       .orderBy('created_at', 'desc')
       .limit(100)
       .onSnapshot(querySnapshot => {

--- a/components/screens/Multiplayer.tsx
+++ b/components/screens/Multiplayer.tsx
@@ -131,7 +131,8 @@ export default function Multiplayer(props: any) {
 
   return (
     <View style={styles.container}>
-      <Button title="Host a Match" onPress={() => createNewLobby()}/>
+      {!committed && <Button title="Host a Match" onPress={() => createNewLobby()} />}
+      
 
       <Text>Matches</Text>
       <FlatList


### PR DESCRIPTION
Prevent players from hosting or joining multiple matches. 

__Bonuses:__  
Adds ~filtering~, limiting, and sorting.

__Nice to have:__
- Debug the filtering of matches. The current setup gets ALL matches, including matches that may have already been played (and don't need to be loaded). For some reason when the filter `.where('status', 'in', ['matchmaking', 'in-progress'])` works, but breaks real-time updating.  
- Might be nice to show some kind of UI around matches that you cannot join/enter, letting the user know that they can't join or enter because they're either already hosting a match, or a player in another.
- Although sorting (by created_at timestamp) was added as a bonus, if you are hosting or a player in a game it should be at the top of the stack.



