### PR TITLE
Start match

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -15,7 +15,9 @@ import Home from './components/screens/Home'
 import Settings from './components/screens/Settings'
 import SinglePlayer from './components/screens/SinglePlayer'
 import Multiplayer from './components/screens/Multiplayer'
-import Matchmaking from './components/screens/Matchmaking'
+import MatchLobby from './components/screens/MatchLobby'
+import JoinMatch from './components/screens/JoinMatch'
+
 import Match from './components/screens/Match'
 
 import { NativeWindStyleSheet } from "nativewind";
@@ -32,7 +34,8 @@ export type RootStackParamList = {
   Settings: undefined
   SinglePlayer: undefined // TODO: Deprecate?
   Multiplayer: undefined // TODO: Deprecate?
-  Matchmaking: { room_code: string | undefined } | undefined
+  JoinMatch: undefined
+  MatchLobby: { room_code: string | undefined } | undefined
   Match: { matchId: string } | undefined
 }
 
@@ -132,8 +135,12 @@ export default function App() {
               {(props: any) => <Settings {...props} user={user} setUser={setUser} />}
             </Stack.Screen>
 
-            <Stack.Screen name="Matchmaking" options={{ title: 'Matchmaking' }} >
-              {(props: any) => <Matchmaking {...props} user={user} />}
+            <Stack.Screen name="JoinMatch" options={{ title: 'Join Match' }} >
+              {(props: any) => <JoinMatch {...props} user={user} />}
+            </Stack.Screen>
+
+            <Stack.Screen name="MatchLobby" options={{ title: 'Match Lobby' }} >
+              {(props: any) => <MatchLobby {...props} user={user} />}
             </Stack.Screen>
 
             <Stack.Screen name="Match" options={{ title: 'Match', headerShown: false }} >

--- a/App.tsx
+++ b/App.tsx
@@ -36,7 +36,7 @@ export type RootStackParamList = {
   Multiplayer: undefined // TODO: Deprecate?
   JoinMatch: undefined
   MatchLobby: { room_code: string | undefined } | undefined
-  Match: { matchId: string } | undefined
+  Match: { room_code: string } | undefined
 }
 
 interface User {

--- a/components/MatchPlayerView.tsx
+++ b/components/MatchPlayerView.tsx
@@ -1,146 +1,14 @@
 import React, { FunctionComponent, useState, useRef } from 'react'
-// import { RNCamera } from 'react-native-camera'
-import { Ionicons, MaterialIcons, MaterialCommunityIcons } from '@expo/vector-icons';
-// import firestore from '@react-native-firebase/firestore'
-// import functions from '@react-native-firebase/functions';
 
-import { StyleSheet, Text, TouchableOpacity, View } from 'react-native'
+import { StyleSheet, View } from 'react-native'
 import { t } from 'react-native-tailwindcss'
-import { ROUND_STATES } from './screens/constants';
-
-import RoundTimer from './RoundTimer'
-
-interface Props {
-  match: Match
-  user: User
-  host: User
-  submitWord: (word: string) => void
-}
-
-interface Label {
-  text: string,
-  confidence: number
-}
-
-const MatchPlayerView: FunctionComponent<Props> = ({match, user, host, submitWord}) => {
-  // let camera = useRef<RNCamera | null>(null)
-  const [labels, setLabels] = useState([])
-  // const [camType, setCamType] = useState(RNCamera.Constants.Type.back)
-  const [camType, setCamType] = useState(null)
 
 
-  const { rounds, players } = match
-  const round = rounds[match.round + 1]
-  const player = players.find(p => p.id === user.id)
-
-  const switchCamera = () => {
-    // if (camType === RNCamera.Constants.Type.back) {
-    //   setCamType(RNCamera.Constants.Type.front);
-    // } else {
-    //   setCamType(RNCamera.Constants.Type.back);
-    // }
-  }
-  const attemptMatch = async () => {
-    // check if round word equals one of the current labels 
-    const submissionHasMatch = labels.find((l:Label) => l.text === round.word)
-    // take a picture and convert it to base64 
-    // const submission = await camera.takePictureAsync({ quality: 0.25, width: '200', base64: true })
-    let submission;
-    let roundsCopy, playersCopy
-    if (submissionHasMatch) {
-      // var playerScored = functions().httpsCallable('playerScored')
-      
-      // playerScored({ 
-      //   match: match,
-      //   confidence: parseInt(submissionHasMatch.confidence * 10),
-      //   player: { name: player.name, id: player.id },
-      //   submission: submission.base64,
-      // })
-    } else {
-      
-      // only set the player's current submission
-      playersCopy = players.map(p => {
-        if (p.id === player.id) {
-          p.submission = submission?.base64
-        }
-        return p
-      })
-
-      // firestore()
-      //   .collection('matches')
-      //   .doc(match.id)
-      //   .update({
-      //     players: playersCopy,
-      //   } as Partial<FirestoreMatch>)
-      //   .then(() => {
-      //     console.log('Match updated!')
-      //   })  
-    }
-  }
+const MatchPlayerView: FunctionComponent<> = () => {
 
   return (
     <View style={[t.flex1, t.flexCol]}>
-      <View style={[t.p4, t.flexRow, t.itemsCenter, { backgroundColor: '#FFE8E7', height: 80 }]}>
-        
-        <Text style={[t.flex1, t.fontBold, t.textXl]}>
-          {round.status === ROUND_STATES.CREATED && !round.word && `${host?.name} is picking a word`}
-          {round.status === ROUND_STATES.STARTED && round.word && `Bring me a... ${round.word}`}
-        </Text>
 
-        <View style={[t.flexRow, t.itemsCenter]}>
-          <MaterialIcons name="timer" size={24} color="black" />
-          <Text style={[t.pL1, t.textXl]}>
-            <RoundTimer round={round}/>
-          </Text>
-        </View>
-
-      </View>
-      <View style={[t.flex1, t.relative]}>
-        {/* <RNCamera
-          ref={ref => {
-            camera = ref;
-          }}
-          style={[t.flex1, t.justifyEnd, t.itemsCenter, { flex: 1 }]}
-          type={camType}
-          flashMode={RNCamera.Constants.FlashMode.off}
-          androidCameraPermissionOptions={{
-            title: 'Permission to use camera',
-            message: 'We need your permission to use your camera',
-            buttonPositive: 'Ok',
-            buttonNegative: 'Cancel',
-          }}
-          androidRecordAudioPermissionOptions={{
-            title: 'Permission to use audio recording',
-            message: 'We need your permission to use your audio',
-            buttonPositive: 'Ok',
-            buttonNegative: 'Cancel',
-          }}
-          onLabelsDetected={({ labels = [] }) => setLabels(labels)}
-        /> */}
-
-        <View style={[t.absolute, t.m4]}>
-          {
-            labels?.sort((a, b) => b.confidence - a.confidence).map((label, labelIndex) => (
-              <Text key={labelIndex} style={[t.p2, t.textWhite, { backgroundColor: 'rgba(0,0,0,0.5)' }]}>{label.text}: {label.confidence}</Text>
-            ))
-          }
-        </View>
-
-      </View>
-
-      <View style={[t.bgBlack, t.pB6, t.pT3, t.pX4, t.flexRow, t.itemsCenter, t.justifyEnd]}>
-
-        <View style={[t.flex1]}></View>
-
-        <TouchableOpacity style={[t.flex1, t.itemsCenter]} onPress={() => attemptMatch()}>
-          <Ionicons name="ios-radio-button-on" size={50} color="white" />
-        </TouchableOpacity>
-
-        <TouchableOpacity style={[t.flex1, t.itemsEnd]} onPress={() => switchCamera()}>
-          <Ionicons name="ios-reverse-camera" size={40} color="white" />
-        </TouchableOpacity>
-
-      </View>
     </View>
   )
 }

--- a/components/PlayerIcon.tsx
+++ b/components/PlayerIcon.tsx
@@ -33,7 +33,7 @@ const PlayerIcon: FunctionComponent<Props> = (props) => {
       <Image source={imgSource} resizeMode="contain" className="h-full w-full"></Image>
       <View className={`absolute ${PLAYER_IMAGES[index].color} self-center w-full h-3/4 ${roundedness} ${position} -z-10`} />
       <View className={`bg-blue-200 px-4 py-0 rounded absolute bottom-3 transform ${translate}`}>
-        <Text className="font-bold lowercase text-bmBlue text-lg">{name}</Text>
+        <Text className="font-bold text-bmBlue text-lg">{name}</Text>
       </View>
     </View>
   )

--- a/components/screens/Home.tsx
+++ b/components/screens/Home.tsx
@@ -23,6 +23,7 @@ const Home: FunctionComponent<Props> = (props) => {
 
   const createMatch = async () => {
     // send request to server to create a new Match
+    // TODO: show a loading state here
     const { data, error } = await supabase.functions.invoke('create-match', {
       body: { user: user },
     })
@@ -33,7 +34,7 @@ const Home: FunctionComponent<Props> = (props) => {
       return
     }
     // if match successfully created, navigate to MatchLobby
-    props.navigation.navigate('Matchmaking', { room_code: data.room_code })
+    props.navigation.navigate('MatchLobby', { room_code: data.room_code })
   }
 
   return (
@@ -61,7 +62,7 @@ const Home: FunctionComponent<Props> = (props) => {
         <StyledButton onPress={() => createMatch()}>
           <StyledButtonText>Create a Match</StyledButtonText>
         </StyledButton>
-        <StyledButton onPress={() => props.navigation.navigate('Matchmaking')}>
+        <StyledButton onPress={() => props.navigation.navigate('JoinMatch')}>
           <StyledButtonText>Join a Match</StyledButtonText>
         </StyledButton>
         <StyledButton onPress={() => props.navigation.navigate('Settings')}>

--- a/components/screens/JoinMatch.tsx
+++ b/components/screens/JoinMatch.tsx
@@ -72,5 +72,5 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
 })
-const StyledInput = styled(TextInput, 'border-bmBlue border-4 my-2 p-4 rounded-[20px] text-black w-full');
+const StyledInput = styled(TextInput, 'border-bmBlue border-4 my-2 p-4 rounded-[20px] text-black w-full')
 

--- a/components/screens/JoinMatch.tsx
+++ b/components/screens/JoinMatch.tsx
@@ -1,0 +1,76 @@
+import React, { useState, FunctionComponent } from 'react'
+import { RouteProp } from '@react-navigation/native'
+import { StackNavigationProp } from '@react-navigation/stack'
+import { StyleSheet, Text, TextInput, View, Alert, Button } from 'react-native'
+import { RootStackParamList } from '../../App'
+import { styled } from "nativewind"
+import { supabase } from '../../supabase/init'
+
+interface User {
+  id: string
+  username: string | null
+}
+interface Match {
+  id: string
+  room_code: string
+  status: string
+  players: User[]
+  host: User
+}
+interface Props {
+  navigation: StackNavigationProp<RootStackParamList>
+  route: RouteProp<RootStackParamList, 'MatchLobby'>
+  user: User
+}
+
+const JoinMatch: FunctionComponent<Props> = (props) => {
+  const { user } = props
+  const [roomCodeInput, setRoomCodeInput] = useState<string>('')
+
+  /* ACTION HANDLERS */
+  const joinMatch = async () => {
+    const { data, error } = await supabase.functions.invoke('join-match', {
+      body: { 
+        user: user, 
+        room_code: roomCodeInput
+      },
+    })
+    // if match creation fails, show an error message
+    if (error?.message) {
+      console.log(error)
+      alert(error.message)
+      return
+    }
+    // if match successfully joined, navigate to MatchLobby
+    props.navigation.navigate('MatchLobby', { room_code: data.room_code })
+  }
+
+  return (
+    <View style={styles.container}>
+      {/* Match not found. Give the user the opportunity to JOIN a match */}
+      <Text>Enter your Room Code to join</Text>
+      <StyledInput
+        onChangeText={text => {
+          setRoomCodeInput(text)
+        }}
+      />
+      <Button 
+        onPress={() => joinMatch()} 
+        title="Join" 
+      />
+    </View>
+  )
+}
+
+export default JoinMatch
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+})
+const StyledInput = styled(TextInput, 'border-bmBlue border-4 my-2 p-4 rounded-[20px] text-black w-full');
+

--- a/components/screens/Match.tsx
+++ b/components/screens/Match.tsx
@@ -53,9 +53,9 @@ const Match: FunctionComponent<Props> = (props) => {
       <View><Text>Loading</Text></View>
     )
   }
-
-  const round = rounds[round_index]
-  return round.leader?.id === user.id ? (
+ 
+  const round = rounds.find((r:any) => r.round_index === round_index)
+  return round.leader === user.id ? (
     <View>
       <Text>Host View</Text>
     </View>

--- a/components/screens/Match.tsx
+++ b/components/screens/Match.tsx
@@ -1,141 +1,69 @@
 import React, { FunctionComponent, useEffect, useState } from 'react'
-import { StyleSheet, Text, View, TouchableOpacity } from 'react-native'
+import { StyleSheet, Text, View, TouchableOpacity, Dimensions } from 'react-native'
 import { RouteProp } from '@react-navigation/native'
-// import { createDrawerNavigator } from '@react-navigation/drawer';
-
-
-// import firestore from '@react-native-firebase/firestore'
-
-import styled from 'styled-components/native'
-import { t } from 'react-native-tailwindcss'
-
+import { StackNavigationProp } from '@react-navigation/stack'
+import { styled } from "nativewind"
+import { useMatchData } from '../../supabase/MatchUtils'
 import MatchHostView from '../MatchHostView'
 import MatchPlayerView from '../MatchPlayerView'
 import Scoreboard from '../Scoreboard'
 import { RootStackParamList } from '../../App'
 
-import { Dimensions } from 'react-native'
-
-/* To Do: 
- * [ ] Wire up the countdown timer for the Round
- * [ ] Style the Match Host View and Match Player View 
- * [ ] Show a notification when a player has won a round 
- * [ ] Show the confidence score for the Winner
- * [ ] Winner score should be based on 100 points + confidence + time remaining
- * [ ] Confidence threshold to win a round 
- * [ ] Show a notification when the game ends, with a 'go back' button 
- * [ ] Slide-out drawer with 'leave match' button and scoreboard 
- * [ ] Hints for selecting a word or submitting a capture
- * [ ] Presence indicator for users (high LOE, requires firebase rtdb ugh)
- * - We can do time last because it's not essential 
-*/
-
-interface Props {
-  user: User
-  route: RouteProp<RootStackParamList, 'Match'>
+interface User {
+  id: string
+  username: string | null
 }
-
-// const Drawer = createDrawerNavigator();
+interface Match {
+  id: string
+  room_code: string
+  status: string
+  players: User[]
+  host: User
+}
+interface Props {
+  navigation: StackNavigationProp<RootStackParamList>
+  route: RouteProp<RootStackParamList, 'Match'>
+  user: User
+}
 
 const Match: FunctionComponent<Props> = (props) => {
   const { user } = props
-  const matchId = props.route.params?.matchId
+  const room_code = props?.route?.params?.room_code
+  const [ matchData, startMatch, leaveMatch ] = useMatchData(room_code)
 
-  if (!matchId) {
-    throw new Error('No match ID passed as route param! Singleplayer not handled yet')
-  }
+  const { 
+    players, 
+    host, 
+    rounds,
+    round_index,
+    status,
+    room_code:code 
+  } = matchData || {}
 
-  const [match, setMatch] = useState<Match>()
-  const [host, setHost] = useState<any>(null)
-
-  // get match by ID passed in with props
+  // On component mount
   useEffect(() => {
-    // firestore()
-    //   .collection('matches')
-    //   .doc(matchId)
-    //   .onSnapshot(documentSnapshot => {
-    //     if (!documentSnapshot) {
-    //       return
-    //     }
-    //     const data = documentSnapshot.data() as FirestoreMatch
-    //     const withId = {
-    //       ...data,
-    //       id: documentSnapshot.id
-    //     }
-    //     setMatch(withId)
-    //   })
-  }, [])
+    if (!matchData) {
+      return
+    } 
+    // TODO: handle back action
+  }, [matchData])
 
-
-  useEffect(() => {
-    return setHost(match?.players[match?.round % match?.players?.length])
-  }, [match?.round])
-
-  const setRoundWord = (word:string) => {
-    if (!match) {
-      throw new Error('No match set. Cannot set round')
-    }
-    let updated = match.rounds
-    updated[match.round + 1].word = word
-    updated[match.round + 1].status = 'started'
-    updated[match.round + 1].started_at = Date.now().toString()
-
-    // firestore()
-    //   .collection('matches')
-    //   .doc(matchId)
-    //   .update('rounds', updated)
-    //   .then(() => {
-    //     console.log('Match Round Word updated!');
-    //   })
-  }  
-
-  const leaveMatch = () => {
-    if (!match) {
-      throw new Error('No match set. Cannot leave match')
-    }
+  if (!matchData) {
+    return (
+      <View><Text>Loading</Text></View>
+    )
   }
 
-  const submitWord = () => {
-
-  }
-
-  if (!match || !host) {
-    return <View><Text>Loading</Text></View>
-  }
-
-  const { width, height } = Dimensions.get('screen');
-
-  return host?.id === user.id ? (
-    // <Drawer.Navigator drawerStyle={{width: '80%'}} drawerPosition="right" drawerContent={() => <DrawerContent match={match} leaveMatch={leaveMatch} host={host}/>}>
-    //   <Drawer.Screen name="MatchHostView" >
-    //     {() => <MatchHostView match={match} setRoundWord={setRoundWord} host={host} />}
-    //   </Drawer.Screen>
-    // </Drawer.Navigator>
+  const round = rounds[round_index]
+  return round.leader?.id === user.id ? (
     <View>
-
+      <Text>Host View</Text>
     </View>
   ) : (
-    // <Drawer.Navigator drawerStyle={{width: '80%'}} drawerPosition="right" drawerContent={() => <DrawerContent match={match} leaveMatch={leaveMatch} host={host}/>}>
-    //   <Drawer.Screen name="MatchPlayerView" component={() => <MatchPlayerView match={match} user={user} host={host} submitWord={submitWord} />} />
-    // </Drawer.Navigator>
     <View>
-      
+      <Text>Player View</Text>
     </View>
   )
-}
-
-function DrawerContent(match, host, leaveMatch) {
-  return <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
-    <View style={[ t.pT10, t.p2, t.flexGrow ]}>
-      <Text style={[ t.fontBold, t.textCenter, t.textXl, t.p2 ]}>Player Scores</Text>
-      <Scoreboard players={match.match.players} host={host}/>
-    </View>
-    <View style={[ t.pB10 ]}>
-      <QuitButton onPress={() => leaveMatch()}>
-        <QuitButtonText>Quit Match</QuitButtonText>
-      </QuitButton>
-    </View>
-  </View>
 }
 
 export default Match
@@ -154,11 +82,3 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
 })
-
-const QuitButton = styled(TouchableOpacity)`
-  ${[ t.p2, t.m2, t.roundedLg, { background: '#ff0000'} ]}
-`;
-
-const QuitButtonText = styled(Text)`
-  ${[ t.fontBold, t.textCenter, t.textLg, t.textWhite, t.uppercase, { fontFamily: 'LuckiestGuy-Regular' } ]}
-`;

--- a/components/screens/MatchLobby.tsx
+++ b/components/screens/MatchLobby.tsx
@@ -159,8 +159,6 @@ const MatchLobby: FunctionComponent<Props> = (props) => {
     // removing the room code should successfully boot the user back to the lobby
     setRoomCode(undefined)
     supabase.removeAllChannels()
-    // WARNING: this could double-up on the onRemove listener
-    props.navigation.navigate('Home')
   }
 
   const startMatch = () => {

--- a/components/screens/MatchLobby.tsx
+++ b/components/screens/MatchLobby.tsx
@@ -32,8 +32,14 @@ const MatchLobby: FunctionComponent<Props> = (props) => {
   const [room_code, setRoomCode] = useState<string | undefined>(() => props?.route?.params?.room_code || undefined)
   const [match, setMatch] = useState<Match>()
 
-  // On component mount, setup "back" confirmation https://reactnavigation.org/docs/preventing-going-back/
+  /* On component mount, setup "back" confirmation https://reactnavigation.org/docs/preventing-going-back/
+   * Note: added match as a dependency key 
+   * because the match is undefined on the first render
+  */ 
   useEffect(() => {
+    if (!match) {
+      return
+    }
     const beforeRemove = (e:any) => {
       e.preventDefault()
       Alert.alert(
@@ -45,10 +51,6 @@ const MatchLobby: FunctionComponent<Props> = (props) => {
             text: 'Leave',
             style: 'destructive',
             onPress: () => {
-              if (!match) {
-                // TODO: show the user an error; maybe try to re-fetch the match?
-                return
-              }
               leaveMatch(match.id, user.id)
               props.navigation.dispatch(e.data.action)    
             },

--- a/components/screens/MatchLobby.tsx
+++ b/components/screens/MatchLobby.tsx
@@ -107,8 +107,17 @@ const MatchLobby: FunctionComponent<Props> = (props) => {
     supabase.removeAllChannels()
   }
 
-  const startMatch = () => {
+  const startMatch = async () => {
+    console.log('starting match')
+    const { data, error } = await supabase.functions.invoke('start-match', {
+      body: { 
+        match_id: matchData?.id
+      },
+    })
 
+    if (error) {
+      return console.log('error starting match: ', error)
+    }
   }
 
   return matchData ? (

--- a/components/screens/MatchLobby.tsx
+++ b/components/screens/MatchLobby.tsx
@@ -32,14 +32,26 @@ const MatchLobby: FunctionComponent<Props> = (props) => {
   const [room_code, setRoomCode] = useState<string | undefined>(() => props?.route?.params?.room_code || undefined)
   const [match, setMatch] = useState<Match>()
 
-  /* On component mount, setup "back" confirmation https://reactnavigation.org/docs/preventing-going-back/
-   * Note: added match as a dependency key 
-   * because the match is undefined on the first render
-  */ 
+  // If the room code changed, get the match data
+  useEffect(() => {
+    if (room_code) {
+      getMatchData()
+    }
+  }, [room_code])
+
   useEffect(() => {
     if (!match) {
       return
     }
+
+    // Once we have a match, subscribe to match updates
+    subscribeToMatchUpdates()
+
+    /* On component mount, setup "back" confirmation 
+     * https://reactnavigation.org/docs/preventing-going-back/
+     * Note: added match as a dependency key 
+     * because the match is undefined on the first render
+    */ 
     const beforeRemove = (e:any) => {
       e.preventDefault()
       Alert.alert(
@@ -64,19 +76,7 @@ const MatchLobby: FunctionComponent<Props> = (props) => {
     }
   }, [match])
 
-  // If the room code changed, get the match data
-  useEffect(() => {
-    if (room_code) {
-      getMatchData()
-    }
-  }, [room_code])
 
-  // If the match changed, subscribe to updates
-  useEffect(() => {
-    if (match) {
-      subscribeToMatchUpdates()
-    }
-  }, [match])
 
   const getMatchData = async () => {
     if (!room_code) {
@@ -95,8 +95,8 @@ const MatchLobby: FunctionComponent<Props> = (props) => {
       .single()
 
     if (matchError || !matchData) {
-      // TODO: Actually handle the error
-      // Possibly re-route to Home and show an error message?
+      // TODO: handle the error
+      // Possibly re-route to Home and show an error message
       console.log('getMatchData match error: ', matchError)
     } else {
       // Overwrite the matchData with the host query response

--- a/components/screens/MatchLobby.tsx
+++ b/components/screens/MatchLobby.tsx
@@ -27,17 +27,39 @@ interface Props {
   user: User
 }
 
+// TODO: Store this in an environment variable
+const MIN_PLAYERS = 2
+
+/* MATCH LOBBY: 
+ * Requires a room_code (passed in via route params)
+ * On component mount, use the room_code to fetch the match data
+ * If a room_code is not provided, the user is bounced back to the home screen 
+ * If a match is found, subscribes to realtime match updates and activates the "back" confirmation
+ * Subscription pings triggers the app to fetch the match data again
+ * Because the subscription payloads aren't the full updated Match object ><
+*/
+
 const MatchLobby: FunctionComponent<Props> = (props) => {
   const { user } = props
-  const [room_code, setRoomCode] = useState<string | undefined>(() => props?.route?.params?.room_code || undefined)
+  const room_code = props?.route?.params?.room_code
   const [match, setMatch] = useState<Match>()
+  const { 
+    players, 
+    host, 
+    room_code:code 
+  } = match || {}
 
-  // If the room code changed, get the match data
+  const readyToStart = players?.length ? players.length >= MIN_PLAYERS : false
+  const isHost = host?.id === user?.id
+
+  // On component mount
   useEffect(() => {
     if (room_code) {
       getMatchData()
+    } else {
+      // Bounce the user back to the home screen
     }
-  }, [room_code])
+  }, [])
 
   useEffect(() => {
     if (!match) {
@@ -50,7 +72,7 @@ const MatchLobby: FunctionComponent<Props> = (props) => {
     /* On component mount, setup "back" confirmation 
      * https://reactnavigation.org/docs/preventing-going-back/
      * Note: added match as a dependency key 
-     * because the match is undefined on the first render
+     *  because the match is undefined on the first render
     */ 
     const beforeRemove = (e:any) => {
       e.preventDefault()
@@ -76,8 +98,7 @@ const MatchLobby: FunctionComponent<Props> = (props) => {
     }
   }, [match])
 
-
-
+  // Fetches the Match from Supabase using the room_code
   const getMatchData = async () => {
     if (!room_code) {
       return
@@ -157,18 +178,12 @@ const MatchLobby: FunctionComponent<Props> = (props) => {
       return
     }
     // removing the room code should successfully boot the user back to the lobby
-    setRoomCode(undefined)
     supabase.removeAllChannels()
   }
 
   const startMatch = () => {
 
   }
-
-  const MIN_PLAYERS = 2
-  const { players, host, room_code: code } = match || {}
-  const readyToStart = players?.length ? players.length >= MIN_PLAYERS : false
-  const isHost = host?.id === user?.id
 
   return match ? (
     <View className="bg-white flex-1 pb-8">

--- a/components/screens/MatchLobby.tsx
+++ b/components/screens/MatchLobby.tsx
@@ -23,15 +23,14 @@ interface Match {
 }
 interface Props {
   navigation: StackNavigationProp<RootStackParamList>
-  route: RouteProp<RootStackParamList, 'Matchmaking'>
+  route: RouteProp<RootStackParamList, 'MatchLobby'>
   user: User
 }
 
-const Matchmaking: FunctionComponent<Props> = (props) => {
+const MatchLobby: FunctionComponent<Props> = (props) => {
   const { user } = props
   const [room_code, setRoomCode] = useState<string | undefined>(() => props?.route?.params?.room_code || undefined)
   const [match, setMatch] = useState<Match>()
-  const [roomCodeInput, setRoomCodeInput] = useState<string>('')
 
   // On component mount, setup "back" confirmation https://reactnavigation.org/docs/preventing-going-back/
   useEffect(() => {
@@ -140,23 +139,6 @@ const Matchmaking: FunctionComponent<Props> = (props) => {
     }
   }
 
-  /* ACTION HANDLERS */
-  const joinMatch = async () => {
-    const { data, error } = await supabase.functions.invoke('join-match', {
-      body: {
-        user: user,
-        room_code: roomCodeInput
-      },
-    })
-    // if match creation fails, show an error message
-    if (error?.message) {
-      alert(error.message)
-      return
-    }
-    // if match successfully joined, navigate to MatchLobby
-    setRoomCode(data.room_code)
-  }
-
   const leaveMatch = async (match_id: string, user_id: string) => {
     if (!match_id || !user_id) {
       return
@@ -237,22 +219,13 @@ const Matchmaking: FunctionComponent<Props> = (props) => {
     </View >
   ) : (
     <View style={styles.container}>
-      {/* Match not found. Give the user the opportunity to JOIN a match */}
-      <Text>Enter your Room Code to join</Text>
-      <StyledInput
-        onChangeText={text => {
-          setRoomCodeInput(text)
-        }}
-      />
-      <Button
-        onPress={() => joinMatch()}
-        title="Join"
-      />
+      {/* Match not found */}
+      <Text>LOADING MATCH</Text>
     </View>
   )
 }
 
-export default Matchmaking
+export default MatchLobby
 
 const styles = StyleSheet.create({
   container: {

--- a/components/screens/Matchmaking.tsx
+++ b/components/screens/Matchmaking.tsx
@@ -118,8 +118,8 @@ const Matchmaking: FunctionComponent<Props> = (props) => {
             event: '*',
             schema: 'public',
             table: 'matches',
-            filter: `id=eq.${match.id}`
-          }, handleMatchUpdates
+            filter: `id=eq.${match.id}` 
+          }, getMatchData
         )
         .on(
           'postgres_changes',
@@ -127,21 +127,17 @@ const Matchmaking: FunctionComponent<Props> = (props) => {
             event: '*',
             schema: 'public',
             table: 'players',
-            filter: `match_id=eq.${match.id}`
-          }, handleMatchUpdates
+            filter: `match_id=eq.${match.id}` 
+          }, getMatchData
         )
         .subscribe((status, err) => {
           if (status) {
             console.log('match status: ', status)
-          } else {
-            console.log(err)
+          } else if (err) {
+            console.log('error subscribing to match updates: ', err.message)
           }
         })
     }
-  }
-
-  const handleMatchUpdates = (payload: any) => {
-    getMatchData()
   }
 
   /* ACTION HANDLERS */

--- a/components/screens/Matchmaking.tsx
+++ b/components/screens/Matchmaking.tsx
@@ -46,7 +46,9 @@ const Matchmaking: FunctionComponent<Props> = (props) => {
             text: 'Leave',
             style: 'destructive',
             onPress: () => {
-              props.navigation.dispatch(e.data.action)
+              // Unsubscribe the listeners
+              leaveMatch()
+              props.navigation.dispatch(e.data.action)    
             },
           },
         ]
@@ -150,6 +152,25 @@ const Matchmaking: FunctionComponent<Props> = (props) => {
     }
     // if match successfully joined, navigate to MatchLobby
     setRoomCode(data.room_code)
+  }
+
+  const leaveMatch = async () => {
+    const { data, error } = await supabase.functions.invoke('leave-match', {
+      body: { 
+        user: user, 
+        room_code: room_code
+      },
+    })
+    // if USER fails to leave the match, show an error message
+    if (error?.message) {
+      alert(error.message)
+      return
+    }
+    // removing the room code should successfully boot the user back to the lobby
+    setRoomCode(undefined)
+    supabase.removeAllChannels()
+    // WARNING: this could double-up on the onRemove listener
+    props.navigation.navigate('Match')
   }
 
   const startMatch = () => {

--- a/components/screens/Matchmaking.tsx
+++ b/components/screens/Matchmaking.tsx
@@ -32,9 +32,10 @@ const Matchmaking: FunctionComponent<Props> = (props) => {
   const [room_code, setRoomCode] = useState<string | undefined>(() => props?.route?.params?.room_code || undefined)
   const [match, setMatch] = useState<Match>()
   const [roomCodeInput, setRoomCodeInput] = useState<string>('')
-  // On component mount, Remove players from the match if they back out of the lobby
+
+  // On component mount, setup "back" confirmation https://reactnavigation.org/docs/preventing-going-back/
   useEffect(() => {
-    props.navigation.addListener('beforeRemove', (e) => {
+    const beforeRemove = (e:any) => {
       e.preventDefault()
       Alert.alert(
         'Leave the Lobby?',
@@ -45,8 +46,8 @@ const Matchmaking: FunctionComponent<Props> = (props) => {
             text: 'Leave',
             style: 'destructive',
             onPress: () => {
-              // Unsubscribe the listeners
               if (!match) {
+                // TODO: show the user an error; maybe try to re-fetch the match?
                 return
               }
               leaveMatch(match.id, user.id)
@@ -55,8 +56,12 @@ const Matchmaking: FunctionComponent<Props> = (props) => {
           },
         ]
       )
-    })
-  }, [])
+    }
+    props.navigation.addListener('beforeRemove', beforeRemove)
+    return () => {
+      props.navigation.removeListener('beforeRemove', beforeRemove)
+    }
+  }, [match])
 
   // If the room code changed, get the match data
   useEffect(() => {

--- a/supabase/MatchUtils.tsx
+++ b/supabase/MatchUtils.tsx
@@ -25,12 +25,13 @@ export function useMatchData(room_code:string | undefined) {
         id,
         room_code,
         status,
+        round_index,
+        rounds ( id, round_index, status, time, started_at, finished_at, time_remaining, points, word, winner, leader ),
         players:users!players ( id, username ),
         host:users!matches_host_fkey ( id, username )
       `)
       .eq('room_code', room_code)
       .single()
-
     if (matchError || !data) {
       // TODO: handle the error
       // Possibly re-route to Home and show an error message
@@ -45,18 +46,8 @@ export function useMatchData(room_code:string | undefined) {
     }
   }
 
-  const [matchData, setMatchData] = useState<any>(() => {
-    return getMatchData()
-  })
-
-  useEffect(() => {
-    if (matchData) {
-      subscribeToMatchUpdates(matchData.id)
-    }
-  }, [matchData])
-
   const subscribeToMatchUpdates = async (matchId:string) => {
-    console.log('subscribing to match updates')
+    console.log(`subscribing to match updates`)
     if (matchId) {
       supabase
         .channel(`matches:${matchId}`)
@@ -80,7 +71,6 @@ export function useMatchData(room_code:string | undefined) {
         )
         .subscribe((status, err) => {
           if (status) {
-            console.log('match status: ', status)
           } else if (err) {
             console.log('error subscribing to match updates: ', err.message)
           }
@@ -88,24 +78,53 @@ export function useMatchData(room_code:string | undefined) {
     }
   }
 
-  const updateMatchData = () => {
-
+  const leaveMatch = async (match_id: string, user_id: string) => {
+    if (!match_id || !user_id) {
+      return
+    }
+    const { error } = await supabase.functions.invoke('leave-match', {
+      body: { 
+        user: user_id, 
+        match: match_id
+      },
+    })
+    // if USER fails to leave the match, show an error message
+    if (error?.message) {
+      alert(error.message)
+      return
+    }
+    // removing the room code should successfully boot the user back to the lobby
+    supabase.removeAllChannels()
   }
 
-  const addPlayerToMatch = () => {
+  const startMatch = async () => {
+    console.log('starting match')
+    const { data, error } = await supabase.functions.invoke('start-match', {
+      body: { 
+        match_id: matchData?.id
+      },
+    })
 
+    if (error) {
+      return console.log('error starting match: ', error)
+    }
   }
 
-  const removePlayerFromMatch = () => {
+  const [matchData, setMatchData] = useState<any>()
 
-  }
+  useEffect(() => {
+    getMatchData()
+  }, [])
+
+  useEffect(() => {
+    if (matchData) {
+      subscribeToMatchUpdates(matchData.id)
+    }
+  }, [matchData])
 
   return [
     matchData,
-    subscribeToMatchUpdates,
-    getMatchData,
-    updateMatchData,
-    addPlayerToMatch,
-    removePlayerFromMatch,
+    startMatch,
+    leaveMatch
   ]
 }

--- a/supabase/MatchUtils.tsx
+++ b/supabase/MatchUtils.tsx
@@ -1,0 +1,111 @@
+import React, { useState, useEffect } from 'react'
+import { supabase } from './init'
+import { MATCH_STATES } from './constants'
+
+interface User {
+  id: string
+  username: string | null
+}
+interface Match {
+  id: string
+  room_code: string
+  status: string
+  players: User[]
+  host: User
+}
+export function useMatchData(room_code:string | undefined) {
+
+  const getMatchData = async () => {
+    if (!room_code) {
+      return {}
+    }
+    let { data, error: matchError } = await supabase
+      .from('matches')
+      .select(`
+        id,
+        room_code,
+        status,
+        players:users!players ( id, username ),
+        host:users!matches_host_fkey ( id, username )
+      `)
+      .eq('room_code', room_code)
+      .single()
+
+    if (matchError || !data) {
+      // TODO: handle the error
+      // Possibly re-route to Home and show an error message
+      console.log('getMatchData match error: ', matchError)
+      return {}
+    } else {
+      setMatchData({
+        ...data,
+        status: data?.status || MATCH_STATES.MATCHMAKING,
+        host: data?.host || { id: '', username: null }
+      })
+    }
+  }
+
+  const [matchData, setMatchData] = useState<any>(() => {
+    return getMatchData()
+  })
+
+  useEffect(() => {
+    if (matchData) {
+      subscribeToMatchUpdates(matchData.id)
+    }
+  }, [matchData])
+
+  const subscribeToMatchUpdates = async (matchId:string) => {
+    console.log('subscribing to match updates')
+    if (matchId) {
+      supabase
+        .channel(`matches:${matchId}`)
+        .on(
+          'postgres_changes',
+          {
+            event: '*',
+            schema: 'public',
+            table: 'matches',
+            filter: `id=eq.${matchId}` 
+          }, getMatchData
+        )
+        .on(
+          'postgres_changes',
+          {
+            event: '*',
+            schema: 'public',
+            table: 'players',
+            filter: `match_id=eq.${matchId}` 
+          }, getMatchData
+        )
+        .subscribe((status, err) => {
+          if (status) {
+            console.log('match status: ', status)
+          } else if (err) {
+            console.log('error subscribing to match updates: ', err.message)
+          }
+        })
+    }
+  }
+
+  const updateMatchData = () => {
+
+  }
+
+  const addPlayerToMatch = () => {
+
+  }
+
+  const removePlayerFromMatch = () => {
+
+  }
+
+  return [
+    matchData,
+    subscribeToMatchUpdates,
+    getMatchData,
+    updateMatchData,
+    addPlayerToMatch,
+    removePlayerFromMatch,
+  ]
+}

--- a/supabase/constants.ts
+++ b/supabase/constants.ts
@@ -1,0 +1,26 @@
+/* Match states: 
+ * enum, can only be one of these, can't be none of these
+ * 'matchmaking': the host creates the match
+ * 'started': the host hits the 'start match' button from the lobby screen
+ * 'in-progress': the host has kicked off the first round
+ * 'incomplete': the host ends the match early, OR all players abandon a match
+ * 'complete': the match ends in the traditional sense
+ * 'archived': the match is either complete/incomplete and soft-deleted
+*/
+
+export const MATCH_STATES = {
+  MATCHMAKING: 'matchmaking',
+  STARTED: 'started',
+  INCOMPLETE: 'incomplete',
+  COMPLETE: 'complete',
+  ARCHIVED: 'archived'
+}
+
+export const ROUND_STATES = {
+  CREATED: 'created',
+  STARTING: 'starting',
+  STARTED: 'started',
+  TIMED_OUT: 'timeout',
+  COMPLETE: 'complete'
+}
+

--- a/supabase/functions/leave-match/index.ts
+++ b/supabase/functions/leave-match/index.ts
@@ -1,0 +1,37 @@
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+
+const supabase_client = createClient(
+  // Supabase API URL - env var exported by default when deployed.
+  Deno.env.get('SUPABASE_URL') ?? '',
+  // Supabase API SERVICE ROLE KEY - env var exported by default when deployed.
+  Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? ''
+)
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+}
+Deno.serve(async (req: any) => {
+  try {
+    const { user, match } = await req.json() // throws an error
+    if (!user || !match) throw new Error("Missing 'user' in request body")
+
+    const { error } = await supabase_client
+      .from('players')
+        .delete()
+        .eq('match_id', match)
+        .eq('user_id', user)
+    return new Response(
+      JSON.stringify({ error }),
+      { 
+        headers: { "Content-Type": "application/json" },
+        status: 200 
+      },
+    )
+  } catch (error: any) {
+    return new Response(JSON.stringify({ error: error.message }), {
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      status: 400,
+    })
+  }
+})
+

--- a/supabase/functions/start-match/index.ts
+++ b/supabase/functions/start-match/index.ts
@@ -1,0 +1,38 @@
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+
+const supabase_client = createClient(
+  // Supabase API URL - env var exported by default when deployed.
+  Deno.env.get('SUPABASE_URL') ?? '',
+  // Supabase API SERVICE ROLE KEY - env var exported by default when deployed.
+  Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? ''
+)
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+}
+Deno.serve(async (req: any) => {
+  try {
+    const { match_id } = await req.json() // throws an error
+    if (!match_id) throw new Error("Missing 'match_id' in request body")
+
+    const { data, error } = await supabase_client
+      .from('matches')
+        .update({ status: 'started' })
+        .eq('id', match_id)
+        .select()
+
+    return new Response(
+      JSON.stringify({ data, error }),
+      { 
+        headers: { "Content-Type": "application/json" },
+        status: 200 
+      },
+    )
+  } catch (error: any) {
+    return new Response(JSON.stringify({ error: error.message }), {
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      status: 400,
+    })
+  }
+})
+


### PR DESCRIPTION
It's not perfect, but...
- Fixes the "leave match" functionality (and the back button) a bit
- Splits "Join Match" screen into it's own screen component (to prevent unnecessary re-renders and data fetching/subs)
- Adds a new MatchUtils hook (useMatchData) to handle data manipulation from supabase
- The host can now start the match from the lobby once the min_players have been reached
- Updates the start_match edge function to set the first round leader
- Sets up the base for the Match screen